### PR TITLE
Fix PropTypes warnings for React 15.5

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -12,6 +12,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactRedux = require('react-redux');
 
 var _utils = require('./utils');
@@ -30,7 +34,7 @@ var IntlProvider = function (_React$Component) {
   function IntlProvider(props) {
     _classCallCheck(this, IntlProvider);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(IntlProvider).call(this, props));
+    var _this = _possibleConstructorReturn(this, (IntlProvider.__proto__ || Object.getPrototypeOf(IntlProvider)).call(this, props));
 
     _this.translate = function (key, placeholders, isHTML) {
       var result = (0, _utils.translateKey)(key, _this.props.translations[_this.props.locale]['messages']);
@@ -65,7 +69,7 @@ var IntlProvider = function (_React$Component) {
 }(_react2.default.Component);
 
 IntlProvider.childContextTypes = {
-  translate: _react2.default.PropTypes.func
+  translate: _propTypes2.default.func
 };
 
 

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.default = function () {
-  var state = arguments.length <= 0 || arguments[0] === undefined ? initialState : arguments[0];
+  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
   var action = arguments[1];
 
   switch (action.type) {

--- a/lib/withTranslate.js
+++ b/lib/withTranslate.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _hoistNonReactStatics = require('hoist-non-react-statics');
 
 var _hoistNonReactStatics2 = _interopRequireDefault(_hoistNonReactStatics);
@@ -26,7 +30,7 @@ exports.default = function (WrappedComponent) {
   };
   WithTranslate.displayName = 'withTranslate(' + getComponentDisplayName(WrappedComponent) + ')';
   WithTranslate.contextTypes = {
-    translate: _react2.default.PropTypes.func
+    translate: _propTypes2.default.func
   };
   return (0, _hoistNonReactStatics2.default)(WithTranslate, WrappedComponent);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-multilingual",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple multilingual translate component and HOC for react and redux",
   "main": "lib/index.js",
   "scripts": {

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,4 +1,5 @@
 import React, { Children } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { supplant, translateKey, createHTMLMarkup } from './utils'
 
@@ -11,7 +12,7 @@ class IntlProvider extends React.Component {
     }
   }
   static childContextTypes = {
-    translate: React.PropTypes.func
+    translate: PropTypes.func
   };
   translate = (key, placeholders, isHTML) => {
     let result = translateKey(key, this.props.translations[this.props.locale]['messages'])

--- a/src/withTranslate.js
+++ b/src/withTranslate.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 
 const getComponentDisplayName = (WrappedComponent) => {
@@ -11,7 +12,7 @@ export default (WrappedComponent) => {
   }
   WithTranslate.displayName = `withTranslate(${getComponentDisplayName(WrappedComponent)})`
   WithTranslate.contextTypes = {
-    translate: React.PropTypes.func
+    translate: PropTypes.func
   }
   return hoistNonReactStatics(WithTranslate, WrappedComponent)
 }


### PR DESCRIPTION
Use the `prop-types` package instead of `React.PropTypes` to avoid the warning:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.